### PR TITLE
Remove un-needed dependencies

### DIFF
--- a/split_dmy.gemspec
+++ b/split_dmy.gemspec
@@ -25,8 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.2'
-  spec.add_development_dependency 'activesupport', '~> 4.0.0'
-  spec.add_development_dependency 'activemodel', '~> 4.0.0'
   spec.add_development_dependency 'activerecord', '~> 4.0.0'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'codeclimate-test-reporter'


### PR DESCRIPTION
closes #24 

As development progressed, more requirements were added but not cleaned up.
